### PR TITLE
Enable annotations in pinned window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,8 @@ set(SOURCES
     src/pinwindow/ImageTransformer.cpp
     src/pinwindow/ResizeHandler.cpp
     src/pinwindow/UIIndicators.cpp
+    src/pinwindow/PinWindowAnnotationController.cpp
+    src/pinwindow/PinWindowToolbar.cpp
     # Scrolling Capture
     src/scrolling/ScrollingCaptureManager.cpp
     src/scrolling/ScrollingCaptureOverlay.cpp
@@ -467,6 +469,8 @@ set(HEADERS
     include/pinwindow/ImageTransformer.h
     include/pinwindow/ResizeHandler.h
     include/pinwindow/UIIndicators.h
+    include/pinwindow/PinWindowAnnotationController.h
+    include/pinwindow/PinWindowToolbar.h
     # Scrolling Capture
     include/scrolling/ScrollingCaptureManager.h
     include/scrolling/ScrollingCaptureOverlay.h

--- a/include/PinWindow.h
+++ b/include/PinWindow.h
@@ -15,6 +15,8 @@ class QTimer;
 class OCRManager;
 class PinWindowManager;
 class UIIndicators;
+class PinWindowAnnotationController;
+class PinWindowToolbar;
 
 class PinWindow : public QWidget
 {
@@ -49,6 +51,10 @@ public:
     // Border visibility
     void setShowBorder(bool enabled);
     bool showBorder() const { return m_showBorder; }
+
+    // Annotation mode
+    void setAnnotationMode(bool enabled);
+    bool isAnnotationMode() const;
 
 signals:
     void closed(PinWindow *window);
@@ -159,6 +165,14 @@ private:
     static constexpr int kResizeThrottleMs = 16;  // ~60fps during resize
 
     int m_baseCornerRadius = 0;
+
+    // Annotation support
+    PinWindowAnnotationController *m_annotationController = nullptr;
+    PinWindowToolbar *m_annotationToolbar = nullptr;
+
+    void setupAnnotationSystem();
+    void updateAnnotationTransformState();
+    void positionAnnotationToolbar();
 };
 
 #endif // PINWINDOW_H

--- a/include/pinwindow/PinWindowAnnotationController.h
+++ b/include/pinwindow/PinWindowAnnotationController.h
@@ -1,0 +1,123 @@
+#ifndef PINWINDOWANNOTATIONCONTROLLER_H
+#define PINWINDOWANNOTATIONCONTROLLER_H
+
+#include <QObject>
+#include <QPoint>
+#include <QPointF>
+#include <QRect>
+#include <QColor>
+#include <memory>
+
+class QWidget;
+class QPainter;
+class QPixmap;
+class AnnotationLayer;
+class ToolManager;
+class ColorAndWidthWidget;
+class InlineTextEditor;
+class TextAnnotationEditor;
+
+/**
+ * @brief Controller for managing annotations in PinWindow.
+ *
+ * This class coordinates all annotation-related functionality including:
+ * - Tool management via ToolManager
+ * - Annotation storage via AnnotationLayer
+ * - Coordinate transformation between screen and image space
+ * - Text annotation editing
+ * - Color/width settings
+ */
+class PinWindowAnnotationController : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit PinWindowAnnotationController(QWidget* parent = nullptr);
+    ~PinWindowAnnotationController() override;
+
+    // Initialization
+    void setSourcePixmap(const QPixmap* pixmap);
+    void setDevicePixelRatio(qreal dpr);
+
+    // Transformation parameters (for coordinate conversion)
+    void setZoomLevel(qreal zoom);
+    void setRotationAngle(int angle);
+    void setFlipState(bool horizontal, bool vertical);
+
+    // Annotation mode
+    bool isAnnotationMode() const { return m_annotationMode; }
+    void setAnnotationMode(bool enabled);
+
+    // Tool management
+    void setCurrentTool(int toolId);
+    int currentTool() const;
+    bool isDrawing() const;
+
+    // Color and width
+    void setColor(const QColor& color);
+    QColor color() const;
+    void setWidth(int width);
+    int width() const;
+
+    // Mouse event handling (in screen coordinates)
+    void handleMousePress(const QPoint& screenPos);
+    void handleMouseMove(const QPoint& screenPos);
+    void handleMouseRelease(const QPoint& screenPos);
+    void handleDoubleClick(const QPoint& screenPos);
+
+    // Drawing
+    void draw(QPainter& painter) const;
+    void drawOntoPixmap(QPixmap& pixmap) const;
+
+    // Text annotation support
+    bool isTextEditing() const;
+    void cancelTextEditing();
+
+    // Undo/Redo
+    void undo();
+    void redo();
+    bool canUndo() const;
+    bool canRedo() const;
+
+    // State
+    bool hasAnnotations() const;
+
+    // Access to sub-components (for toolbar integration)
+    ColorAndWidthWidget* colorAndWidthWidget() const { return m_colorAndWidthWidget.get(); }
+    AnnotationLayer* annotationLayer() const { return m_annotationLayer.get(); }
+
+signals:
+    void annotationModeChanged(bool enabled);
+    void toolChanged(int toolId);
+    void needsRepaint();
+    void undoRedoStateChanged();
+
+private:
+    // Coordinate transformation
+    QPoint screenToImage(const QPoint& screenPos) const;
+    QPoint imageToScreen(const QPoint& imagePos) const;
+
+    // Create painter transform for drawing annotations
+    void setupPainterTransform(QPainter& painter) const;
+
+    // Components
+    std::unique_ptr<AnnotationLayer> m_annotationLayer;
+    std::unique_ptr<ToolManager> m_toolManager;
+    std::unique_ptr<ColorAndWidthWidget> m_colorAndWidthWidget;
+    std::unique_ptr<InlineTextEditor> m_textEditor;
+    std::unique_ptr<TextAnnotationEditor> m_textAnnotationEditor;
+
+    // State
+    bool m_annotationMode = false;
+    QWidget* m_parentWidget = nullptr;
+
+    // Transformation state
+    qreal m_zoomLevel = 1.0;
+    int m_rotationAngle = 0;
+    bool m_flipHorizontal = false;
+    bool m_flipVertical = false;
+    qreal m_devicePixelRatio = 1.0;
+    const QPixmap* m_sourcePixmap = nullptr;
+};
+
+#endif // PINWINDOWANNOTATIONCONTROLLER_H

--- a/include/pinwindow/PinWindowToolbar.h
+++ b/include/pinwindow/PinWindowToolbar.h
@@ -1,0 +1,188 @@
+#ifndef PINWINDOWTOOLBAR_H
+#define PINWINDOWTOOLBAR_H
+
+#include <QWidget>
+#include <QVector>
+#include <QColor>
+#include "tools/ToolId.h"
+#include "annotations/ArrowAnnotation.h"
+#include "annotations/LineStyle.h"
+#include "annotations/ShapeAnnotation.h"
+#include "annotations/StepBadgeAnnotation.h"
+#include "ui/sections/MosaicBlurTypeSection.h"
+
+class ToolbarWidget;
+class ColorAndWidthWidget;
+class QPaintEvent;
+class QMouseEvent;
+class QWheelEvent;
+
+/**
+ * @brief Floating toolbar for PinWindow annotations.
+ *
+ * Provides tool selection buttons and color/width settings for
+ * annotating pinned screenshots.
+ *
+ * Supported tools:
+ * - Shape (Rectangle/Ellipse)
+ * - Arrow
+ * - Pencil
+ * - Marker
+ * - Text
+ * - Mosaic
+ * - Step Badge
+ * - Eraser
+ * - Undo/Redo
+ */
+class PinWindowToolbar : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PinWindowToolbar(QWidget* parent = nullptr);
+    ~PinWindowToolbar() override;
+
+    /**
+     * @brief Set the current active tool.
+     */
+    void setCurrentTool(ToolId tool);
+
+    /**
+     * @brief Get the current active tool.
+     */
+    ToolId currentTool() const { return m_currentTool; }
+
+    /**
+     * @brief Set the current color.
+     */
+    void setColor(const QColor& color);
+
+    /**
+     * @brief Get the current color.
+     */
+    QColor color() const;
+
+    /**
+     * @brief Set the current width.
+     */
+    void setWidth(int width);
+
+    /**
+     * @brief Get the current width.
+     */
+    int width() const;
+
+    /**
+     * @brief Set undo/redo availability.
+     */
+    void setUndoEnabled(bool enabled);
+    void setRedoEnabled(bool enabled);
+
+    /**
+     * @brief Position the toolbar relative to the parent window.
+     * @param parentRect The parent window's rect
+     */
+    void positionRelativeTo(const QRect& parentRect);
+
+    /**
+     * @brief Show/hide the color and width widget.
+     */
+    void setColorWidthWidgetVisible(bool visible);
+
+signals:
+    /**
+     * @brief Emitted when a tool is selected.
+     */
+    void toolSelected(ToolId tool);
+
+    /**
+     * @brief Emitted when color changes.
+     */
+    void colorChanged(const QColor& color);
+
+    /**
+     * @brief Emitted when width changes.
+     */
+    void widthChanged(int width);
+
+    /**
+     * @brief Emitted when undo is requested.
+     */
+    void undoRequested();
+
+    /**
+     * @brief Emitted when redo is requested.
+     */
+    void redoRequested();
+
+    /**
+     * @brief Emitted when close/done is requested.
+     */
+    void closeRequested();
+
+    /**
+     * @brief Emitted when arrow style changes.
+     */
+    void arrowStyleChanged(LineEndStyle style);
+
+    /**
+     * @brief Emitted when line style changes.
+     */
+    void lineStyleChanged(LineStyle style);
+
+    /**
+     * @brief Emitted when shape type changes.
+     */
+    void shapeTypeChanged(ShapeType type);
+
+    /**
+     * @brief Emitted when shape fill mode changes.
+     */
+    void shapeFillModeChanged(ShapeFillMode mode);
+
+    /**
+     * @brief Emitted when step badge size changes.
+     */
+    void stepBadgeSizeChanged(StepBadgeSize size);
+
+    /**
+     * @brief Emitted when mosaic blur type changes.
+     */
+    void mosaicBlurTypeChanged(MosaicBlurTypeSection::BlurType type);
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
+    void leaveEvent(QEvent* event) override;
+
+private:
+    void setupUI();
+    void setupToolbar();
+    void setupColorWidthWidget();
+    void connectSignals();
+    void updateToolbarButtons();
+    void updateColorWidthVisibility();
+    QColor getIconColor(int buttonId, bool isActive, bool isHovered) const;
+
+    // Components
+    ToolbarWidget* m_toolbar;
+    ColorAndWidthWidget* m_colorAndWidthWidget;
+
+    // State
+    ToolId m_currentTool = ToolId::Pencil;
+    bool m_undoEnabled = false;
+    bool m_redoEnabled = false;
+
+    // Dragging
+    bool m_isDragging = false;
+    QPoint m_dragStartPos;
+
+    // Layout
+    static constexpr int kToolbarSpacing = 8;
+    static constexpr int kMargin = 10;
+};
+
+#endif // PINWINDOWTOOLBAR_H

--- a/src/pinwindow/PinWindowAnnotationController.cpp
+++ b/src/pinwindow/PinWindowAnnotationController.cpp
@@ -1,0 +1,458 @@
+#include "pinwindow/PinWindowAnnotationController.h"
+#include "annotations/AnnotationLayer.h"
+#include "tools/ToolManager.h"
+#include "tools/ToolId.h"
+#include "ColorAndWidthWidget.h"
+#include "InlineTextEditor.h"
+#include "region/TextAnnotationEditor.h"
+#include "settings/AnnotationSettingsManager.h"
+
+#include <QWidget>
+#include <QPainter>
+#include <QPixmap>
+#include <QTransform>
+#include <QDebug>
+#include <QtMath>
+
+PinWindowAnnotationController::PinWindowAnnotationController(QWidget* parent)
+    : QObject(parent)
+    , m_annotationLayer(std::make_unique<AnnotationLayer>())
+    , m_toolManager(std::make_unique<ToolManager>())
+    , m_colorAndWidthWidget(std::make_unique<ColorAndWidthWidget>())
+    , m_parentWidget(parent)
+{
+    // Register tool handlers
+    m_toolManager->registerDefaultHandlers();
+    m_toolManager->setAnnotationLayer(m_annotationLayer.get());
+
+    // Connect tool manager signals
+    connect(m_toolManager.get(), &ToolManager::needsRepaint,
+            this, &PinWindowAnnotationController::needsRepaint);
+    connect(m_toolManager.get(), &ToolManager::toolChanged,
+            this, [this](ToolId tool) {
+                emit toolChanged(static_cast<int>(tool));
+            });
+
+    // Connect annotation layer signals
+    connect(m_annotationLayer.get(), &AnnotationLayer::modified,
+            this, &PinWindowAnnotationController::undoRedoStateChanged);
+
+    // Load saved settings
+    auto& settings = AnnotationSettingsManager::instance();
+    m_toolManager->setColor(settings.loadColor());
+    m_toolManager->setWidth(settings.loadWidth());
+
+    // Create text editor for text annotations
+    if (m_parentWidget) {
+        m_textEditor = std::make_unique<InlineTextEditor>(m_parentWidget);
+        m_textAnnotationEditor = std::make_unique<TextAnnotationEditor>(this);
+        m_textAnnotationEditor->setAnnotationLayer(m_annotationLayer.get());
+        m_textAnnotationEditor->setTextEditor(m_textEditor.get());
+        m_textAnnotationEditor->setColorAndWidthWidget(m_colorAndWidthWidget.get());
+        m_textAnnotationEditor->setParentWidget(m_parentWidget);
+
+        // Connect text editor signals
+        connect(m_textEditor.get(), &InlineTextEditor::editingFinished,
+                this, [this](const QString& text, const QPoint& position) {
+                    m_textAnnotationEditor->finishEditing(text, position, m_toolManager->color());
+                    emit needsRepaint();
+                });
+        connect(m_textEditor.get(), &InlineTextEditor::editingCancelled,
+                this, [this]() {
+                    m_textAnnotationEditor->cancelEditing();
+                    emit needsRepaint();
+                });
+        connect(m_textAnnotationEditor.get(), &TextAnnotationEditor::updateRequested,
+                this, &PinWindowAnnotationController::needsRepaint);
+    }
+
+    // Set default tool to Selection
+    m_toolManager->setCurrentTool(ToolId::Selection);
+
+    qDebug() << "PinWindowAnnotationController: Initialized";
+}
+
+PinWindowAnnotationController::~PinWindowAnnotationController() = default;
+
+void PinWindowAnnotationController::setSourcePixmap(const QPixmap* pixmap)
+{
+    m_sourcePixmap = pixmap;
+    m_toolManager->setSourcePixmap(pixmap);
+}
+
+void PinWindowAnnotationController::setDevicePixelRatio(qreal dpr)
+{
+    m_devicePixelRatio = dpr;
+    m_toolManager->setDevicePixelRatio(dpr);
+}
+
+void PinWindowAnnotationController::setZoomLevel(qreal zoom)
+{
+    m_zoomLevel = zoom;
+}
+
+void PinWindowAnnotationController::setRotationAngle(int angle)
+{
+    m_rotationAngle = angle;
+}
+
+void PinWindowAnnotationController::setFlipState(bool horizontal, bool vertical)
+{
+    m_flipHorizontal = horizontal;
+    m_flipVertical = vertical;
+}
+
+void PinWindowAnnotationController::setAnnotationMode(bool enabled)
+{
+    if (m_annotationMode == enabled) {
+        return;
+    }
+
+    m_annotationMode = enabled;
+
+    if (!m_annotationMode) {
+        // Exit annotation mode - cancel any in-progress operations
+        m_toolManager->cancelDrawing();
+        if (m_textEditor && m_textEditor->isEditing()) {
+            m_textEditor->cancelEditing();
+        }
+        m_annotationLayer->clearSelection();
+    }
+
+    emit annotationModeChanged(m_annotationMode);
+    emit needsRepaint();
+
+    qDebug() << "PinWindowAnnotationController: Annotation mode" << (enabled ? "enabled" : "disabled");
+}
+
+void PinWindowAnnotationController::setCurrentTool(int toolId)
+{
+    m_toolManager->setCurrentTool(static_cast<ToolId>(toolId));
+}
+
+int PinWindowAnnotationController::currentTool() const
+{
+    return static_cast<int>(m_toolManager->currentTool());
+}
+
+bool PinWindowAnnotationController::isDrawing() const
+{
+    return m_toolManager->isDrawing();
+}
+
+void PinWindowAnnotationController::setColor(const QColor& color)
+{
+    m_toolManager->setColor(color);
+    m_colorAndWidthWidget->setCurrentColor(color);
+
+    // Save to settings
+    AnnotationSettingsManager::instance().saveColor(color);
+}
+
+QColor PinWindowAnnotationController::color() const
+{
+    return m_toolManager->color();
+}
+
+void PinWindowAnnotationController::setWidth(int width)
+{
+    m_toolManager->setWidth(width);
+    m_colorAndWidthWidget->setCurrentWidth(width);
+
+    // Save to settings
+    AnnotationSettingsManager::instance().saveWidth(width);
+}
+
+int PinWindowAnnotationController::width() const
+{
+    return m_toolManager->width();
+}
+
+QPoint PinWindowAnnotationController::screenToImage(const QPoint& screenPos) const
+{
+    // Convert from screen coordinates to image coordinates
+    // Account for zoom, rotation, and flip
+
+    QPointF pos = QPointF(screenPos);
+
+    // Reverse zoom
+    pos /= m_zoomLevel;
+
+    // Get image size (after rotation)
+    if (!m_sourcePixmap) {
+        return pos.toPoint();
+    }
+
+    QSize imageSize = m_sourcePixmap->size() / m_sourcePixmap->devicePixelRatio();
+
+    // For rotation, we need to handle width/height swap for 90/270 degrees
+    QSize transformedSize = imageSize;
+    if (m_rotationAngle == 90 || m_rotationAngle == 270) {
+        transformedSize = QSize(imageSize.height(), imageSize.width());
+    }
+
+    // Reverse flip
+    if (m_flipHorizontal) {
+        pos.setX(transformedSize.width() - pos.x());
+    }
+    if (m_flipVertical) {
+        pos.setY(transformedSize.height() - pos.y());
+    }
+
+    // Reverse rotation
+    if (m_rotationAngle != 0) {
+        QTransform transform;
+        transform.translate(transformedSize.width() / 2.0, transformedSize.height() / 2.0);
+        transform.rotate(-m_rotationAngle);
+        transform.translate(-imageSize.width() / 2.0, -imageSize.height() / 2.0);
+        pos = transform.map(pos);
+    }
+
+    return pos.toPoint();
+}
+
+QPoint PinWindowAnnotationController::imageToScreen(const QPoint& imagePos) const
+{
+    // Convert from image coordinates to screen coordinates
+    QPointF pos = QPointF(imagePos);
+
+    if (!m_sourcePixmap) {
+        return (pos * m_zoomLevel).toPoint();
+    }
+
+    QSize imageSize = m_sourcePixmap->size() / m_sourcePixmap->devicePixelRatio();
+
+    // Apply rotation
+    if (m_rotationAngle != 0) {
+        QTransform transform;
+        transform.translate(imageSize.width() / 2.0, imageSize.height() / 2.0);
+        transform.rotate(m_rotationAngle);
+        if (m_rotationAngle == 90 || m_rotationAngle == 270) {
+            transform.translate(-imageSize.height() / 2.0, -imageSize.width() / 2.0);
+        } else {
+            transform.translate(-imageSize.width() / 2.0, -imageSize.height() / 2.0);
+        }
+        pos = transform.map(pos);
+    }
+
+    // Get size after rotation
+    QSize transformedSize = imageSize;
+    if (m_rotationAngle == 90 || m_rotationAngle == 270) {
+        transformedSize = QSize(imageSize.height(), imageSize.width());
+    }
+
+    // Apply flip
+    if (m_flipHorizontal) {
+        pos.setX(transformedSize.width() - pos.x());
+    }
+    if (m_flipVertical) {
+        pos.setY(transformedSize.height() - pos.y());
+    }
+
+    // Apply zoom
+    pos *= m_zoomLevel;
+
+    return pos.toPoint();
+}
+
+void PinWindowAnnotationController::setupPainterTransform(QPainter& painter) const
+{
+    // Set up transform to draw annotations in screen space
+    // Annotations are stored in image coordinates, so we need to transform them
+
+    if (!m_sourcePixmap) {
+        painter.scale(m_zoomLevel, m_zoomLevel);
+        return;
+    }
+
+    QSize imageSize = m_sourcePixmap->size() / m_sourcePixmap->devicePixelRatio();
+    QSize transformedSize = imageSize;
+    if (m_rotationAngle == 90 || m_rotationAngle == 270) {
+        transformedSize = QSize(imageSize.height(), imageSize.width());
+    }
+
+    // Apply transforms in reverse order
+    painter.scale(m_zoomLevel, m_zoomLevel);
+
+    // Apply flip
+    if (m_flipHorizontal || m_flipVertical) {
+        painter.translate(transformedSize.width() / 2.0, transformedSize.height() / 2.0);
+        painter.scale(m_flipHorizontal ? -1 : 1, m_flipVertical ? -1 : 1);
+        painter.translate(-transformedSize.width() / 2.0, -transformedSize.height() / 2.0);
+    }
+
+    // Apply rotation
+    if (m_rotationAngle != 0) {
+        painter.translate(transformedSize.width() / 2.0, transformedSize.height() / 2.0);
+        painter.rotate(m_rotationAngle);
+        painter.translate(-imageSize.width() / 2.0, -imageSize.height() / 2.0);
+    }
+}
+
+void PinWindowAnnotationController::handleMousePress(const QPoint& screenPos)
+{
+    if (!m_annotationMode) {
+        return;
+    }
+
+    // Handle text editor click
+    if (m_textEditor && m_textEditor->isEditing()) {
+        if (m_textEditor->isConfirmMode() && !m_textEditor->contains(screenPos)) {
+            // Click outside text editor in confirm mode - finish editing
+            m_textEditor->finishEditing();
+            return;
+        }
+        if (m_textEditor->contains(screenPos)) {
+            m_textEditor->handleMousePress(screenPos);
+            return;
+        }
+    }
+
+    // Convert to image coordinates
+    QPoint imagePos = screenToImage(screenPos);
+
+    // Handle Text tool specially
+    if (m_toolManager->currentTool() == ToolId::Text) {
+        if (m_textAnnotationEditor && !m_textEditor->isEditing()) {
+            QRect bounds = m_parentWidget ? m_parentWidget->rect() : QRect();
+            m_textAnnotationEditor->startEditing(screenPos, bounds, m_toolManager->color());
+        }
+        return;
+    }
+
+    // Dispatch to tool manager
+    m_toolManager->handleMousePress(imagePos);
+    emit needsRepaint();
+}
+
+void PinWindowAnnotationController::handleMouseMove(const QPoint& screenPos)
+{
+    if (!m_annotationMode) {
+        return;
+    }
+
+    // Handle text editor drag
+    if (m_textEditor && m_textEditor->isDragging()) {
+        m_textEditor->handleMouseMove(screenPos);
+        return;
+    }
+
+    // Convert to image coordinates
+    QPoint imagePos = screenToImage(screenPos);
+
+    // Dispatch to tool manager
+    m_toolManager->handleMouseMove(imagePos);
+    emit needsRepaint();
+}
+
+void PinWindowAnnotationController::handleMouseRelease(const QPoint& screenPos)
+{
+    if (!m_annotationMode) {
+        return;
+    }
+
+    // Handle text editor release
+    if (m_textEditor && m_textEditor->isDragging()) {
+        m_textEditor->handleMouseRelease(screenPos);
+        return;
+    }
+
+    // Convert to image coordinates
+    QPoint imagePos = screenToImage(screenPos);
+
+    // Dispatch to tool manager
+    m_toolManager->handleMouseRelease(imagePos);
+    emit needsRepaint();
+}
+
+void PinWindowAnnotationController::handleDoubleClick(const QPoint& screenPos)
+{
+    if (!m_annotationMode) {
+        return;
+    }
+
+    // Convert to image coordinates
+    QPoint imagePos = screenToImage(screenPos);
+
+    // Dispatch to tool manager
+    m_toolManager->handleDoubleClick(imagePos);
+    emit needsRepaint();
+}
+
+void PinWindowAnnotationController::draw(QPainter& painter) const
+{
+    if (m_annotationLayer->isEmpty() && !m_toolManager->isDrawing()) {
+        return;
+    }
+
+    painter.save();
+
+    // Set up transform for drawing annotations
+    setupPainterTransform(painter);
+
+    // Draw annotations
+    m_annotationLayer->draw(painter);
+
+    // Draw current tool preview
+    if (m_toolManager->isDrawing()) {
+        m_toolManager->drawCurrentPreview(painter);
+    }
+
+    painter.restore();
+}
+
+void PinWindowAnnotationController::drawOntoPixmap(QPixmap& pixmap) const
+{
+    if (m_annotationLayer->isEmpty()) {
+        return;
+    }
+
+    QPainter painter(&pixmap);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setRenderHint(QPainter::SmoothPixmapTransform);
+
+    // Draw annotations directly onto the pixmap (no transform needed since
+    // annotations are stored in image coordinates)
+    m_annotationLayer->draw(painter);
+}
+
+bool PinWindowAnnotationController::isTextEditing() const
+{
+    return m_textEditor && m_textEditor->isEditing();
+}
+
+void PinWindowAnnotationController::cancelTextEditing()
+{
+    if (m_textEditor && m_textEditor->isEditing()) {
+        m_textEditor->cancelEditing();
+    }
+}
+
+void PinWindowAnnotationController::undo()
+{
+    m_annotationLayer->undo();
+    emit undoRedoStateChanged();
+    emit needsRepaint();
+}
+
+void PinWindowAnnotationController::redo()
+{
+    m_annotationLayer->redo();
+    emit undoRedoStateChanged();
+    emit needsRepaint();
+}
+
+bool PinWindowAnnotationController::canUndo() const
+{
+    return m_annotationLayer->canUndo();
+}
+
+bool PinWindowAnnotationController::canRedo() const
+{
+    return m_annotationLayer->canRedo();
+}
+
+bool PinWindowAnnotationController::hasAnnotations() const
+{
+    return !m_annotationLayer->isEmpty();
+}

--- a/src/pinwindow/PinWindowToolbar.cpp
+++ b/src/pinwindow/PinWindowToolbar.cpp
@@ -1,0 +1,452 @@
+#include "pinwindow/PinWindowToolbar.h"
+#include "ToolbarWidget.h"
+#include "ColorAndWidthWidget.h"
+#include "IconRenderer.h"
+#include "GlassRenderer.h"
+#include "ToolbarStyle.h"
+#include "settings/AnnotationSettingsManager.h"
+
+#include <QPainter>
+#include <QMouseEvent>
+#include <QWheelEvent>
+#include <QDebug>
+
+namespace {
+// Button IDs for PinWindow toolbar
+enum PinWindowToolbarButton {
+    ButtonShape = static_cast<int>(ToolId::Shape),
+    ButtonArrow = static_cast<int>(ToolId::Arrow),
+    ButtonPencil = static_cast<int>(ToolId::Pencil),
+    ButtonMarker = static_cast<int>(ToolId::Marker),
+    ButtonText = static_cast<int>(ToolId::Text),
+    ButtonMosaic = static_cast<int>(ToolId::Mosaic),
+    ButtonStepBadge = static_cast<int>(ToolId::StepBadge),
+    ButtonEraser = static_cast<int>(ToolId::Eraser),
+    ButtonUndo = 100,
+    ButtonRedo = 101,
+    ButtonDone = 102
+};
+}
+
+PinWindowToolbar::PinWindowToolbar(QWidget* parent)
+    : QWidget(parent)
+    , m_toolbar(nullptr)
+    , m_colorAndWidthWidget(nullptr)
+{
+    // Frameless, stays on top, tool window
+    setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Tool);
+    setAttribute(Qt::WA_TranslucentBackground);
+    setAttribute(Qt::WA_ShowWithoutActivating);
+
+    setupUI();
+    connectSignals();
+
+    // Initial size
+    updateGeometry();
+
+    qDebug() << "PinWindowToolbar: Initialized";
+}
+
+PinWindowToolbar::~PinWindowToolbar() = default;
+
+void PinWindowToolbar::setupUI()
+{
+    setupToolbar();
+    setupColorWidthWidget();
+}
+
+void PinWindowToolbar::setupToolbar()
+{
+    m_toolbar = new ToolbarWidget(this);
+
+    // Load icons
+    auto& iconRenderer = IconRenderer::instance();
+    iconRenderer.loadIcon("shape", ":/icons/icons/shape.svg");
+    iconRenderer.loadIcon("arrow", ":/icons/icons/arrow.svg");
+    iconRenderer.loadIcon("pencil", ":/icons/icons/pencil.svg");
+    iconRenderer.loadIcon("marker", ":/icons/icons/marker.svg");
+    iconRenderer.loadIcon("text", ":/icons/icons/text.svg");
+    iconRenderer.loadIcon("mosaic", ":/icons/icons/mosaic.svg");
+    iconRenderer.loadIcon("step-badge", ":/icons/icons/step-badge.svg");
+    iconRenderer.loadIcon("eraser", ":/icons/icons/eraser.svg");
+    iconRenderer.loadIcon("undo", ":/icons/icons/undo.svg");
+    iconRenderer.loadIcon("redo", ":/icons/icons/redo.svg");
+    iconRenderer.loadIcon("done", ":/icons/icons/done.svg");
+
+    // Configure buttons
+    QVector<ToolbarWidget::ButtonConfig> buttons;
+    buttons.append({ ButtonShape, "shape", "Shape (S)", false });
+    buttons.append({ ButtonArrow, "arrow", "Arrow (A)", false });
+    buttons.append({ ButtonPencil, "pencil", "Pencil (P)", false });
+    buttons.append({ ButtonMarker, "marker", "Marker (H)", false });
+    buttons.append({ ButtonText, "text", "Text (T)", false });
+    buttons.append({ ButtonMosaic, "mosaic", "Mosaic (M)", false });
+    buttons.append({ ButtonStepBadge, "step-badge", "Step Badge (B)", false });
+    buttons.append(ToolbarWidget::ButtonConfig(ButtonEraser, "eraser", "Eraser (E)").separator());
+    buttons.append(ToolbarWidget::ButtonConfig(ButtonUndo, "undo", "Undo (Ctrl+Z)").separator());
+    buttons.append({ ButtonRedo, "redo", "Redo (Ctrl+Y)", false });
+    buttons.append(ToolbarWidget::ButtonConfig(ButtonDone, "done", "Done (Enter)").separator().action());
+
+    m_toolbar->setButtons(buttons);
+
+    // Set which buttons can be active (drawing tools)
+    QVector<int> activeButtonIds = {
+        ButtonShape,
+        ButtonArrow,
+        ButtonPencil,
+        ButtonMarker,
+        ButtonText,
+        ButtonMosaic,
+        ButtonStepBadge,
+        ButtonEraser
+    };
+    m_toolbar->setActiveButtonIds(activeButtonIds);
+
+    // Set default active button
+    m_toolbar->setActiveButton(ButtonPencil);
+
+    // Set icon color provider
+    ToolbarStyleConfig styleConfig = ToolbarStyleConfig::getStyle(ToolbarStyleConfig::loadStyle());
+    m_toolbar->setStyleConfig(styleConfig);
+    m_toolbar->setIconColorProvider([this](int buttonId, bool isActive, bool isHovered) {
+        return getIconColor(buttonId, isActive, isHovered);
+    });
+}
+
+void PinWindowToolbar::setupColorWidthWidget()
+{
+    m_colorAndWidthWidget = new ColorAndWidthWidget(this);
+
+    // Load settings
+    auto& settings = AnnotationSettingsManager::instance();
+    m_colorAndWidthWidget->setCurrentColor(settings.loadColor());
+    m_colorAndWidthWidget->setCurrentWidth(settings.loadWidth());
+
+    // Configure initial visibility
+    updateColorWidthVisibility();
+}
+
+void PinWindowToolbar::connectSignals()
+{
+    // Toolbar button clicks
+    connect(m_toolbar, &ToolbarWidget::buttonClicked, this, [this](int buttonId) {
+        switch (buttonId) {
+        case ButtonUndo:
+            emit undoRequested();
+            break;
+        case ButtonRedo:
+            emit redoRequested();
+            break;
+        case ButtonDone:
+            emit closeRequested();
+            break;
+        default:
+            // Tool button
+            m_currentTool = static_cast<ToolId>(buttonId);
+            m_toolbar->setActiveButton(buttonId);
+            updateColorWidthVisibility();
+            emit toolSelected(m_currentTool);
+            update();
+            break;
+        }
+    });
+
+    // Color widget signals
+    connect(m_colorAndWidthWidget, &ColorAndWidthWidget::colorSelected, this, [this](const QColor& color) {
+        AnnotationSettingsManager::instance().saveColor(color);
+        emit colorChanged(color);
+        update();
+    });
+
+    connect(m_colorAndWidthWidget, &ColorAndWidthWidget::widthChanged, this, [this](int width) {
+        AnnotationSettingsManager::instance().saveWidth(width);
+        emit widthChanged(width);
+        update();
+    });
+
+    // Arrow style
+    connect(m_colorAndWidthWidget, &ColorAndWidthWidget::arrowStyleChanged,
+            this, &PinWindowToolbar::arrowStyleChanged);
+
+    // Line style
+    connect(m_colorAndWidthWidget, &ColorAndWidthWidget::lineStyleChanged,
+            this, &PinWindowToolbar::lineStyleChanged);
+
+    // Shape signals
+    connect(m_colorAndWidthWidget, &ColorAndWidthWidget::shapeTypeChanged,
+            this, &PinWindowToolbar::shapeTypeChanged);
+    connect(m_colorAndWidthWidget, &ColorAndWidthWidget::shapeFillModeChanged,
+            this, &PinWindowToolbar::shapeFillModeChanged);
+
+    // Step badge size
+    connect(m_colorAndWidthWidget, &ColorAndWidthWidget::stepBadgeSizeChanged,
+            this, &PinWindowToolbar::stepBadgeSizeChanged);
+
+    // Mosaic blur type
+    connect(m_colorAndWidthWidget, &ColorAndWidthWidget::mosaicBlurTypeChanged,
+            this, &PinWindowToolbar::mosaicBlurTypeChanged);
+}
+
+void PinWindowToolbar::updateColorWidthVisibility()
+{
+    // Configure color/width widget based on current tool
+    bool showColor = true;
+    bool showWidth = true;
+    bool showArrowStyle = false;
+    bool showLineStyle = false;
+    bool showShapeSection = false;
+    bool showTextSection = false;
+    bool showMosaicWidth = false;
+    bool showMosaicBlurType = false;
+    bool showSizeSection = false;
+
+    switch (m_currentTool) {
+    case ToolId::Shape:
+        showShapeSection = true;
+        showLineStyle = true;
+        break;
+    case ToolId::Arrow:
+        showArrowStyle = true;
+        showLineStyle = true;
+        break;
+    case ToolId::Pencil:
+        showLineStyle = true;
+        break;
+    case ToolId::Marker:
+        showWidth = false;
+        break;
+    case ToolId::Text:
+        showWidth = false;
+        showTextSection = true;
+        break;
+    case ToolId::Mosaic:
+        showColor = false;
+        showWidth = false;
+        showMosaicWidth = true;
+        showMosaicBlurType = true;
+        break;
+    case ToolId::StepBadge:
+        showWidth = false;
+        showSizeSection = true;
+        break;
+    case ToolId::Eraser:
+        showColor = false;
+        break;
+    default:
+        break;
+    }
+
+    m_colorAndWidthWidget->setShowColorSection(showColor);
+    m_colorAndWidthWidget->setShowWidthSection(showWidth);
+    m_colorAndWidthWidget->setShowArrowStyleSection(showArrowStyle);
+    m_colorAndWidthWidget->setShowLineStyleSection(showLineStyle);
+    m_colorAndWidthWidget->setShowShapeSection(showShapeSection);
+    m_colorAndWidthWidget->setShowTextSection(showTextSection);
+    m_colorAndWidthWidget->setShowMosaicWidthSection(showMosaicWidth);
+    m_colorAndWidthWidget->setShowMosaicBlurTypeSection(showMosaicBlurType);
+    m_colorAndWidthWidget->setShowSizeSection(showSizeSection);
+}
+
+QColor PinWindowToolbar::getIconColor(int buttonId, bool isActive, bool isHovered) const
+{
+    ToolbarStyleConfig styleConfig = ToolbarStyleConfig::getStyle(ToolbarStyleConfig::loadStyle());
+
+    // Done button uses action color
+    if (buttonId == ButtonDone) {
+        return styleConfig.iconActionColor;
+    }
+
+    // Undo/Redo - check enabled state
+    if (buttonId == ButtonUndo && !m_undoEnabled) {
+        return styleConfig.iconNormalColor.darker(150);
+    }
+    if (buttonId == ButtonRedo && !m_redoEnabled) {
+        return styleConfig.iconNormalColor.darker(150);
+    }
+
+    // Active tool
+    if (isActive) {
+        return styleConfig.iconActiveColor;
+    }
+
+    // Hovered
+    if (isHovered) {
+        return styleConfig.iconNormalColor;
+    }
+
+    return styleConfig.iconNormalColor;
+}
+
+void PinWindowToolbar::setCurrentTool(ToolId tool)
+{
+    m_currentTool = tool;
+    m_toolbar->setActiveButton(static_cast<int>(tool));
+    updateColorWidthVisibility();
+    update();
+}
+
+void PinWindowToolbar::setColor(const QColor& color)
+{
+    m_colorAndWidthWidget->setCurrentColor(color);
+}
+
+QColor PinWindowToolbar::color() const
+{
+    return m_colorAndWidthWidget->currentColor();
+}
+
+void PinWindowToolbar::setWidth(int width)
+{
+    m_colorAndWidthWidget->setCurrentWidth(width);
+}
+
+int PinWindowToolbar::width() const
+{
+    return m_colorAndWidthWidget->currentWidth();
+}
+
+void PinWindowToolbar::setUndoEnabled(bool enabled)
+{
+    m_undoEnabled = enabled;
+    update();
+}
+
+void PinWindowToolbar::setRedoEnabled(bool enabled)
+{
+    m_redoEnabled = enabled;
+    update();
+}
+
+void PinWindowToolbar::positionRelativeTo(const QRect& parentRect)
+{
+    // Position toolbar below the parent window, centered
+    int x = parentRect.center().x() - width() / 2;
+    int y = parentRect.bottom() + kToolbarSpacing;
+
+    move(x, y);
+}
+
+void PinWindowToolbar::setColorWidthWidgetVisible(bool visible)
+{
+    m_colorAndWidthWidget->setVisible(visible);
+    update();
+}
+
+void PinWindowToolbar::paintEvent(QPaintEvent*)
+{
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    ToolbarStyleConfig styleConfig = ToolbarStyleConfig::getStyle(ToolbarStyleConfig::loadStyle());
+
+    // Draw glass background
+    QRect bgRect = rect().adjusted(kMargin, kMargin, -kMargin, -kMargin);
+    GlassRenderer::drawGlassPanel(painter, bgRect, styleConfig);
+
+    // Calculate toolbar position within the widget
+    QRect toolbarRect = m_toolbar->boundingRect();
+    int toolbarX = (width() - toolbarRect.width()) / 2;
+    int toolbarY = kMargin + (32 - toolbarRect.height()) / 2 + 4;
+
+    // Translate painter for toolbar drawing
+    painter.save();
+    painter.translate(toolbarX, toolbarY);
+    m_toolbar->draw(painter);
+    m_toolbar->drawTooltip(painter);
+    painter.restore();
+
+    // Draw color/width widget if visible
+    if (m_colorAndWidthWidget->isVisible()) {
+        // Position color widget below toolbar
+        QRect colorRect(kMargin, kMargin + 32 + 4, width() - 2 * kMargin, 32);
+        m_colorAndWidthWidget->updatePosition(colorRect, false, width());
+        m_colorAndWidthWidget->draw(painter);
+    }
+}
+
+void PinWindowToolbar::mousePressEvent(QMouseEvent* event)
+{
+    if (event->button() == Qt::LeftButton) {
+        // Check if click is on toolbar
+        QRect toolbarRect = m_toolbar->boundingRect();
+        int toolbarX = (width() - toolbarRect.width()) / 2;
+        int toolbarY = kMargin + (32 - toolbarRect.height()) / 2 + 4;
+
+        QPoint toolbarPos = event->pos() - QPoint(toolbarX, toolbarY);
+        int buttonId = m_toolbar->buttonAtPosition(toolbarPos);
+
+        if (buttonId >= 0) {
+            emit m_toolbar->buttonClicked(buttonId);
+            event->accept();
+            return;
+        }
+
+        // Check color/width widget
+        if (m_colorAndWidthWidget->isVisible() && m_colorAndWidthWidget->contains(event->pos())) {
+            m_colorAndWidthWidget->handleMousePress(event->pos());
+            event->accept();
+            return;
+        }
+
+        // Start dragging
+        m_isDragging = true;
+        m_dragStartPos = event->globalPosition().toPoint() - frameGeometry().topLeft();
+    }
+    event->accept();
+}
+
+void PinWindowToolbar::mouseMoveEvent(QMouseEvent* event)
+{
+    if (m_isDragging) {
+        move(event->globalPosition().toPoint() - m_dragStartPos);
+        return;
+    }
+
+    // Update hover state
+    QRect toolbarRect = m_toolbar->boundingRect();
+    int toolbarX = (width() - toolbarRect.width()) / 2;
+    int toolbarY = kMargin + (32 - toolbarRect.height()) / 2 + 4;
+
+    QPoint toolbarPos = event->pos() - QPoint(toolbarX, toolbarY);
+    if (m_toolbar->updateHoveredButton(toolbarPos)) {
+        update();
+    }
+
+    // Color/width widget hover
+    if (m_colorAndWidthWidget->isVisible()) {
+        bool pressed = event->buttons() & Qt::LeftButton;
+        if (m_colorAndWidthWidget->handleMouseMove(event->pos(), pressed)) {
+            update();
+        }
+    }
+}
+
+void PinWindowToolbar::mouseReleaseEvent(QMouseEvent* event)
+{
+    if (event->button() == Qt::LeftButton) {
+        m_isDragging = false;
+
+        // Color/width widget release
+        if (m_colorAndWidthWidget->isVisible()) {
+            m_colorAndWidthWidget->handleMouseRelease(event->pos());
+        }
+    }
+    event->accept();
+}
+
+void PinWindowToolbar::wheelEvent(QWheelEvent* event)
+{
+    // Forward to color/width widget
+    if (m_colorAndWidthWidget->isVisible()) {
+        if (m_colorAndWidthWidget->handleWheel(event->angleDelta().y())) {
+            update();
+        }
+    }
+    event->accept();
+}
+
+void PinWindowToolbar::leaveEvent(QEvent*)
+{
+    m_toolbar->updateHoveredButton(QPoint(-1, -1));
+    update();
+}


### PR DESCRIPTION
- Create PinWindowAnnotationController to manage annotation state
- Create PinWindowToolbar with annotation tool selection
- Support Shape, Arrow, Pencil, Marker, Text, Mosaic, Step Badge, Eraser
- Handle coordinate transformation for zoom/rotation/flip
- Include annotations in exported images (save/copy)
- Add context menu option and keyboard shortcut (A) for annotation mode
- Support undo/redo with Ctrl+Z/Ctrl+Y shortcuts