### PR TITLE
fix(hotkey): canonicalize Windows Print Screen conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog is curated for release notes. GitHub Releases and the website rel
 ### Fixed
 
 - Fixed Windows `Print Screen` hotkey registration so SnapTray maps Qt's `Print` sequence to the Windows `VK_SNAPSHOT` key.
+- Fixed Windows `Print Screen` hotkey conflict detection for older `Native:0x2C` settings.
 - Improved the Windows `Print Screen` hotkey conflict warning with Snipping Tool settings guidance.
 
 ## [1.0.52] - 2026-05-07

--- a/src/hotkey/HotkeyManager.cpp
+++ b/src/hotkey/HotkeyManager.cpp
@@ -96,6 +96,26 @@ std::optional<QHotkey::NativeShortcut> windowsNativeShortcutForSequence(const QS
         windowsNativeModifierMask(modifiers));
 }
 #endif
+
+QString conflictKeyForSequence(const QString& keySequence)
+{
+    const QString normalized = normalizeKeySequence(keySequence);
+
+#ifdef Q_OS_WIN
+    if (normalized == QStringLiteral("native:0x2c")) {
+        return QStringLiteral("win-native:0x2c:0");
+    }
+
+    if (const auto nativeShortcut = windowsNativeShortcutForSequence(keySequence);
+        nativeShortcut && nativeShortcut->key == kWindowsVirtualKeySnapshot) {
+        return QStringLiteral("win-native:0x%1:%2")
+            .arg(nativeShortcut->key, 0, 16)
+            .arg(nativeShortcut->modifier);
+    }
+#endif
+
+    return normalized;
+}
 }  // namespace
 
 HotkeyManager::HotkeyManager()
@@ -286,7 +306,7 @@ std::optional<HotkeyAction> HotkeyManager::preferredConflictOwner(HotkeyAction a
         return std::nullopt;
     }
 
-    const QString normalizedSequence = normalizeKeySequence(config.keySequence);
+    const QString normalizedSequence = conflictKeyForSequence(config.keySequence);
     HotkeyAction preferredOwner = action;
 
     for (auto it = m_configs.begin(); it != m_configs.end(); ++it) {
@@ -299,7 +319,7 @@ std::optional<HotkeyAction> HotkeyManager::preferredConflictOwner(HotkeyAction a
             continue;
         }
 
-        if (normalizeKeySequence(other.keySequence) != normalizedSequence) {
+        if (conflictKeyForSequence(other.keySequence) != normalizedSequence) {
             continue;
         }
 
@@ -364,10 +384,10 @@ void HotkeyManager::refreshAffectedConflicts(const QString& oldSequence,
 {
     QSet<QString> affectedSequences;
     if (!oldSequence.isEmpty()) {
-        affectedSequences.insert(normalizeKeySequence(oldSequence));
+        affectedSequences.insert(conflictKeyForSequence(oldSequence));
     }
     if (!newSequence.isEmpty()) {
-        affectedSequences.insert(normalizeKeySequence(newSequence));
+        affectedSequences.insert(conflictKeyForSequence(newSequence));
     }
 
     if (affectedSequences.isEmpty()) {
@@ -384,7 +404,7 @@ void HotkeyManager::refreshAffectedConflicts(const QString& oldSequence,
             continue;
         }
 
-        if (!affectedSequences.contains(normalizeKeySequence(config.keySequence))) {
+        if (!affectedSequences.contains(conflictKeyForSequence(config.keySequence))) {
             continue;
         }
 
@@ -599,7 +619,7 @@ std::optional<HotkeyAction> HotkeyManager::hasConflict(const QString& keySequenc
         return std::nullopt;
     }
 
-    const QString normalizedSequence = normalizeKeySequence(keySequence);
+    const QString normalizedSequence = conflictKeyForSequence(keySequence);
     std::optional<HotkeyAction> preferredConflict;
 
     for (auto it = m_configs.begin(); it != m_configs.end(); ++it) {
@@ -612,7 +632,7 @@ std::optional<HotkeyAction> HotkeyManager::hasConflict(const QString& keySequenc
             continue;
         }
 
-        const QString otherNormalized = normalizeKeySequence(config.keySequence);
+        const QString otherNormalized = conflictKeyForSequence(config.keySequence);
         if (normalizedSequence == otherNormalized) {
             if (!preferredConflict || hasHigherRegistrationPriority(it.key(), *preferredConflict)) {
                 preferredConflict = it.key();

--- a/tests/Hotkey/tst_HotkeyManager.cpp
+++ b/tests/Hotkey/tst_HotkeyManager.cpp
@@ -53,6 +53,7 @@ private slots:
     void testHasConflict_NoConflict();
     void testHasConflict_DetectsConflict();
     void testHasConflict_ExcludesSelf();
+    void testHasConflict_TreatsWindowsNativePrintAndPrintAsSameShortcut();
 
     // Reset tests
     void testResetToDefault_RestoresOriginal();
@@ -411,6 +412,29 @@ void tst_HotkeyManager::testHasConflict_ExcludesSelf()
     // When excluding self, should not conflict
     auto conflict = manager().hasConflict(config.keySequence, HotkeyAction::RegionCapture);
     QVERIFY(!conflict.has_value());
+}
+
+void tst_HotkeyManager::testHasConflict_TreatsWindowsNativePrintAndPrintAsSameShortcut()
+{
+#ifndef Q_OS_WIN
+    QSKIP("Windows Print Screen canonicalization is only available on Windows.");
+#else
+    using namespace SnapTray;
+
+    manager().shutdown();
+    clearAllTestSettings();
+    manager().m_registerHotkeyOverride = [](HotkeyAction, const QString&) {
+        return true;
+    };
+    manager().initialize();
+
+    QVERIFY(manager().updateHotkey(HotkeyAction::PinFromImage, QStringLiteral("Native:0x2C")));
+
+    const auto conflict = manager().hasConflict(QStringLiteral("Print"),
+                                                HotkeyAction::RegionCapture);
+    QVERIFY(conflict.has_value());
+    QCOMPARE(*conflict, HotkeyAction::PinFromImage);
+#endif
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Canonicalize Windows Print Screen conflict checks so `Print` and legacy `Native:0x2C` settings share the same shortcut identity.
- Add a regression test covering the legacy native Print Screen setting against the new `Print` sequence.
- Note the conflict detection fix in `CHANGELOG.md`.

Fixes #90

## Tests
- `scripts\\build.bat`
- `ctest -R "Hotkey_(HotkeyManager|TypeHotkeyDialog)|Settings_(SettingsBackend|QmlTranslations)" --output-on-failure`